### PR TITLE
Fixing sub_filters_types for proper js rewrite

### DIFF
--- a/services/nginx/teslamate.conf
+++ b/services/nginx/teslamate.conf
@@ -23,7 +23,7 @@ server {
         proxy_set_header Accept-Encoding "";
         
         # Enable sub-filtering
-        sub_filter_types text/css text/xml application/javascript;
+        sub_filter_types text/css text/xml application/javascript text/javascript;
         sub_filter_once off;
 
         # Home URLs in the HTML


### PR DESCRIPTION
Found a fix for https://github.com/matt-FFFFFF/hassio-addon-teslamate/issues/58 - just missing a proper meta type for nginx rewrite config.