### PR TITLE
Update ha-bootstrap.sh to specify DEFAULT_GEOFENCE

### DIFF
--- a/scripts/ha-bootstrap.sh
+++ b/scripts/ha-bootstrap.sh
@@ -15,6 +15,7 @@ export MQTT_PASSWORD=$(bashio::config 'mqtt_pass')
 export MQTT_TLS_ACCEPT_INVALID_CERTS=$(bashio::config 'mqtt_tls_accept_invalid_certs')
 export MQTT_TLS=$(bashio::config 'mqtt_tls')
 export MQTT_USERNAME=$(bashio::config 'mqtt_user')
+export DEFAULT_GEOFENCE='not_home'
 
 
 # Other things


### PR DESCRIPTION
Currently hardwired but maybe a more generalized solution of extending to all supported environment variables can be invented by you instead