### PR TITLE
Bump Teslamate to 1.28.3

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,5 +1,5 @@
 {
     "args": {
-      "TESLAMATE_TAG": "1.28.2"
+      "TESLAMATE_TAG": "1.28.3"
     }
 }


### PR DESCRIPTION
closes #125 

No further investigation was performed. Assuming that only the Teslamate version must be increased. Feel free to drop the MR if is not the case