### PR TITLE
Taking account of new Teslamate (> 1.28.4) dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ FROM teslamate/grafana:${TESLAMATE_TAG} as grafana
 FROM teslamate/teslamate:${TESLAMATE_TAG}
 
 ARG ARCH
-ARG BASHIO_VERSION=0.11.0
-ARG S6_OVERLAY_VERSION=2.1.0.2
+ARG BASHIO_VERSION=0.16.2
+ARG S6_OVERLAY_VERSION=3.1.6.2
 
 ENV \
     DEBIAN_FRONTEND="noninteractive" \
@@ -31,11 +31,27 @@ RUN \
         nginx \
         tzdata \
         wget \
-    && rm -rf /var/lib/apt/lists/* \
+        xz-utils
+
+# From version 3.0.0.0 of S6-overlay, the amd64 architecture is renamed x86_64
+RUN \
+    set -x \
+    && S6_ARCH=$(if [ "$ARCH" = "amd64" ]; then echo "x86_64"; else echo $ARCH; fi) \
     \
-    && wget https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${ARCH}.tar.gz \
-    && tar zxvf s6-overlay-${ARCH}.tar.gz -C / \
-    && rm -f s6-overlay-${ARCH}.tar.gz \
+    && wget https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz \
+    && tar -C / -Jxpf s6-overlay-noarch.tar.xz \
+    && rm s6-overlay-noarch.tar.xz \
+    \
+    && wget https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz \
+    && tar -C / -Jxpf s6-overlay-${S6_ARCH}.tar.xz \
+    && rm s6-overlay-${S6_ARCH}.tar.xz \
+    \
+    && wget https://github.com/just-containers/s6-overlay/releases/download/v3.1.6.2/s6-overlay-symlinks-noarch.tar.xz \
+    && tar -C / -Jxpf s6-overlay-symlinks-noarch.tar.xz \
+    && rm s6-overlay-symlinks-noarch.tar.xz
+
+RUN \
+    set -x \
     && mkdir -p /etc/fix-attrs.d \
     && mkdir -p /etc/services.d \
     \
@@ -47,14 +63,11 @@ RUN \
     && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
     && rm -rf /tmp/bashio
 
-COPY --chown=root scripts/*.sh /
-RUN chmod a+x /*.sh
+COPY --chown=root --chmod=555 scripts/*.sh /
 
-COPY --chown=root services/teslamate/run services/teslamate/finish /etc/services.d/teslamate/
-RUN chmod a+x /etc/services.d/teslamate/*
+COPY --chown=root --chmod=555 services/teslamate/run services/teslamate/finish /etc/services.d/teslamate/
 
-COPY --chown=root services/nginx/run services/nginx/finish /etc/services.d/nginx/
-RUN chmod a+x /etc/services.d/nginx/*
+COPY --chown=root --chmod=555 services/nginx/run services/nginx/finish /etc/services.d/nginx/
 
 COPY --chown=root services/nginx/teslamate.conf /etc/nginx/conf.d/
 

--- a/config.json
+++ b/config.json
@@ -12,6 +12,7 @@
     "startup": "application",
     "boot": "auto",
     "ingress": true,
+    "init": false,
     "panel_icon": "mdi:car-connected",
     "panel_title": "TeslaMate",
     "options": {


### PR DESCRIPTION
In version 1.28.4, Teslamate has been upgraded to the Debian "bookworm" version and uses "netcat-openbsd". Decompressing S6-overlay in version 2.1.0.2 overwritten the /bin/ directory and some commands were no longer present (sh, nc etc...). Upgrading S6-overlay to version 3.1.6.2 solves this problem. S6-overlay-symlinks-noarch has been added for backward compatibility.
